### PR TITLE
ssh-agent updated to Node v16 compatible version

### DIFF
--- a/.github/workflows/frontend-docker-image.yml
+++ b/.github/workflows/frontend-docker-image.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         node-version: 16
     - name: set ssh key
-      uses: webfactory/ssh-agent@v0.5.4
+      uses: webfactory/ssh-agent@v0.7.0
       with:
         ssh-private-key: ${{ secrets.JENKINS_SSH_KEY }}
     - name: environment variables


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/